### PR TITLE
Add renderButton prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ ReactDOM.render(<Example />, document.getElementById("root"));
 | `innerButtonCount` | number | 2 | The number of displayed standard page buttons adjacent to the current button. Allow a number greater than or equal to `0`. |
 | `nextPageLabel` | node | '>' | The content of the next page button. |
 | `onClick` | func |  | Callback fired when the button is clicked.<br><br>Signature:<br>`function(event: object, offset: number, page: number) => void`<br>event: The event source of the callback.<br>offset: The number of new offset.<br>page: The number of new page. |
+| `renderButton` | ({page, offset, children} => ReactElement) |  | This is a "render-prop" function that lets you wrap a page button with whatever you want. Main use case is to use `<a>` anchor for pagination: `({ page, children }) => <a href={`?page=${page}`}>{children}</a>` |
 | `otherPageColor` | enum:<br>&nbsp;'default' &#124;<br>&nbsp;'inherit' &#124;<br>&nbsp;'primary' &#124;<br>&nbsp;'secondary' | 'primary' | The color of the buttons of other pages excluding the current page. |
 | `outerButtonCount` | number | 2 | The number of standard page buttons displayed at the end. Allow a number greater than or equal to `1`. |
 | `previousPageLabel` | node | '<' | The content of the previous page button. |

--- a/src/PageButton.tsx
+++ b/src/PageButton.tsx
@@ -4,6 +4,7 @@ import Button, { ButtonProps } from '@material-ui/core/Button';
 import { createStyles, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 import { getOffset } from './core';
+import { RenderButtonProps } from './Pagination';
 
 export type PageButtonClassKey =
   | 'root'
@@ -110,6 +111,7 @@ export interface PageButtonProps extends StandardProps<ButtonProps, PageButtonCl
   pageVariant: PageVariant;
   currentPageColor?: PropTypes.Color;
   onClick?: (ev: React.MouseEvent<HTMLElement>, offset: number, page: number) => void;
+  renderButton?: (props: RenderButtonProps) => React.ReactElement;
   otherPageColor?: PropTypes.Color;
 }
 
@@ -134,6 +136,7 @@ const PageButton: React.FunctionComponent<
     disabled: disabledProp,
     disableRipple: disableRippleProp,
     onClick: onClickProp,
+    renderButton,
     otherPageColor,
     size,
     ...other
@@ -189,12 +192,13 @@ const PageButton: React.FunctionComponent<
   const color = isCurrent ? currentPageColor : otherPageColor;
   const disabled = disabledProp || isEllipsis || page <= 0 || total <= 0;
   const disableRipple = disableRippleProp || disabled || isCurrent;
+  const isClickable = !disabled && (isEnd || isStandard);
   let onClick: ((ev: React.MouseEvent<HTMLElement>) => void) | undefined;
-  if (onClickProp && !disabled && (isEnd || isStandard)) {
+  if (isClickable && onClickProp) {
     onClick = handleClick(page, limit, onClickProp);
   }
 
-  return (
+  const button = (
     <Button
       classes={classes}
       color={color}
@@ -205,6 +209,12 @@ const PageButton: React.FunctionComponent<
       {...other}
     />
   );
+
+  if (renderButton && isClickable) {
+    return renderButton({ offset: getOffset(page, limit), page, children: button });
+  }
+
+  return button;
 };
 
 PageButton.defaultProps = {

--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -34,6 +34,12 @@ const styles = createStyles<PaginationClassKey, PaginationProps>({
   fullWidth: {}
 });
 
+export interface RenderButtonProps {
+  offset: number;
+  page: number;
+  children: React.ReactNode;
+}
+
 export interface PaginationProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, PaginationClassKey, 'onClick'> {
   limit: number;
@@ -49,6 +55,7 @@ export interface PaginationProps
   innerButtonCount?: number;
   nextPageLabel?: React.ReactNode;
   onClick?: (ev: React.MouseEvent<HTMLElement>, offset: number, page: number) => void;
+  renderButton?: (props: RenderButtonProps) => React.ReactElement;
   otherPageColor?: PropTypes.Color;
   outerButtonCount?: number;
   previousPageLabel?: React.ReactNode;
@@ -75,6 +82,7 @@ const Pagination: React.FunctionComponent<
     nextPageLabel,
     innerButtonCount: innerButtonCountProp,
     onClick,
+    renderButton,
     otherPageColor,
     outerButtonCount: outerButtonCountProp,
     previousPageLabel,
@@ -137,6 +145,7 @@ const Pagination: React.FunctionComponent<
               fullWidth={fullWidth}
               key={key}
               onClick={onClick}
+              renderButton={renderButton}
               otherPageColor={otherPageColor}
               pageVariant={pageVariant}
               size={size}

--- a/tests/PageButton.spec.tsx
+++ b/tests/PageButton.spec.tsx
@@ -214,4 +214,39 @@ describe('PageButton', () => {
       });
     });
   });
+
+  describe('renderButton prop', () => {
+    describe('using page', () => {
+      const wrapper = mount(
+        <PageButton
+          page={1}
+          limit={10}
+          total={10}
+          pageVariant="current"
+          renderButton={({ page, children }) => <a href={`?page=${page}`}>{children}</a>}
+        >
+          {1}
+        </PageButton>
+      );
+
+      const link = wrapper.find('a');
+      expect(link.prop('href')).toEqual('?page=1');
+    });
+    describe('using offset', () => {
+      const wrapper = mount(
+        <PageButton
+          page={1}
+          limit={10}
+          total={10}
+          pageVariant="current"
+          renderButton={({ offset, children }) => <a href={`?offset=${offset}`}>{children}</a>}
+        >
+          {1}
+        </PageButton>
+      );
+
+      const link = wrapper.find('a');
+      expect(link.prop('href')).toEqual('?offset=0');
+    });
+  });
 });


### PR DESCRIPTION
This enables the developer to use html anchor or react-router `<Link>` instead of buttons for the pagination.

Fixes #9